### PR TITLE
fix(ci): Correct OCI artifact publishing workflow

### DIFF
--- a/.github/workflows/containerize.yaml
+++ b/.github/workflows/containerize.yaml
@@ -1,0 +1,59 @@
+name: Version, Build and Push Container
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  version-build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push tags
+      packages: write # Required to push packages to GHCR
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for semver-action to analyze commit history
+
+      - name: Calculate next version
+        id: semver
+        uses: ietf-tools/semver-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          noVersionBumpBehavior: patch
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.semver.outputs.nextStrict }}
+            ghcr.io/${{ github.repository }}:latest
+        # This step builds the image and tags it with the new version and 'latest'.
+
+      - name: Install Flux CLI
+        uses: fluxcd/flux2/action@main
+
+      - name: Push Kustomization artifact to GHCR
+        run: |
+          flux push artifact oci://ghcr.io/${{ lower(github.repository) }}/manifests:${{ steps.semver.outputs.nextStrict }} \
+            --path="./flux" \
+            --source="${{ github.server_url }}/${{ github.repository }}" \
+            --revision="${{ steps.semver.outputs.next }}"
+
+      - name: Create and push Git tag
+        # This step runs only after all artifacts have been successfully pushed.
+        run: |
+          git tag ${{ steps.semver.outputs.next }}
+          git push origin ${{ steps.semver.outputs.next }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to this project
+
+We love seeing contributions from the community! Thank you for your interest in making this project better.
+
+## How to Contribute
+
+There are several ways you can contribute to this project:
+
+- **Reporting Bugs**: If you find a bug, please open an issue and provide as much detail as possible.
+- **Suggesting Enhancements**: If you have an idea for a new feature or an improvement to an existing one, open an issue to discuss it.
+- **Pull Requests**: If you've fixed a bug or implemented a new feature, you can submit a pull request.
+
+## Reporting Bugs
+
+Before reporting a bug, please search the existing issues to see if someone has already reported it. If not, create a new issue and include:
+
+- A clear and descriptive title.
+- A detailed description of the problem.
+- Steps to reproduce the bug.
+- Any relevant logs or error messages.
+
+## Submitting a Pull Request
+
+1.  **Fork the repository** to your own GitHub account.
+2.  **Create a new branch** for your changes (`git checkout -b feature/my-new-feature` or `git checkout -b fix/bug-fix`).
+3.  **Make your changes**. Ensure your code follows the project's style and conventions.
+4.  **Commit your changes** with a clear and descriptive commit message.
+5.  **Push your branch** to your fork (`git push origin feature/my-new-feature`).
+6.  **Open a pull request** from your fork to the main repository.
+
+We will review your pull request as soon as possible. Thank you for your contribution!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Use an official lightweight Python image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container
+COPY requirements.txt .
+
+# Install the Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the application script
+COPY sync_recordings.py .
+
+# Set the command to run the script when the container starts
+# Note: The user will need to mount volumes for `recordings` and `state.json`
+# as described in the README.md to ensure data persistence.
+CMD ["python", "sync_recordings.py"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,89 @@
-# legendary-giggle
+# VoIP.ms Call Recording Synchronization Script
+
+This project provides a robust Python script to periodically synchronize call recordings from your VoIP.ms account to a local directory. The script is idempotent, resilient to network issues, and designed to be run by a scheduler like `cron`.
+
+## Features
+
+- **Idempotent**: Keeps track of downloaded files and won't download the same recording twice.
+- **Resilient**: Implements a retry mechanism with exponential backoff for API requests.
+- **Memory-Efficient**: Downloads large files in chunks to minimize memory usage.
+- **Configurable**: All credentials and paths are managed via a `config.ini` file.
+- **Containerized**: Includes a `Dockerfile` for easy deployment.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.7+
+- A VoIP.ms account with API access enabled.
+
+### Installation
+
+1.  **Clone the repository:**
+    ```bash
+    git clone https://github.com/your-username/legendary-giggle.git
+    cd legendary-giggle
+    ```
+
+2.  **Install dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+## Configuration
+
+Before running the script, you need to configure your credentials and paths.
+
+1.  **Copy the example configuration:**
+    The `config.ini` file is where you'll store your settings. A template is provided in the root directory.
+
+2.  **Edit `config.ini`:**
+    Open `config.ini` and replace the placeholder values with your actual VoIP.ms credentials and desired paths.
+
+    ```ini
+    [voipms]
+    username = YOUR_VOIPMS_USERNAME
+    password = YOUR_VOIPMS_PASSWORD
+
+    [paths]
+    download_dir = ./recordings
+    state_file = ./state.json
+    ```
+    - `username`: Your VoIP.ms API username.
+    - `password`: Your VoIP.ms API password.
+    - `download_dir`: The local directory where audio files will be saved.
+    - `state_file`: The path to the JSON file that tracks downloaded recordings.
+
+## Usage
+
+To run the synchronization script manually, execute the following command in your terminal:
+
+```bash
+python sync_recordings.py
+```
+
+The script will log its progress to the console. It is recommended to automate the execution of this script using a scheduler.
+
+### Scheduling with Cron (Linux/macOS)
+
+To run the script every hour, you can add the following line to your crontab:
+
+```bash
+0 * * * * /usr/bin/python3 /path/to/your/project/sync_recordings.py >> /path/to/your/project/sync.log 2>&1
+```
+
+## Docker
+
+You can also run the script in a Docker container for a more isolated environment.
+
+1.  **Build the Docker image:**
+    ```bash
+    docker build -t voipms-sync .
+    ```
+
+2.  **Run the container:**
+    Make sure your `config.ini` is correctly filled out. The container will use it to run the script.
+    ```bash
+    docker run --rm -v "$(pwd)/recordings:/app/recordings" -v "$(pwd)/state.json:/app/state.json" voipms-sync
+    ```
+    - The `-v` flags mount the local `recordings` directory and `state.json` file into the container. This ensures that your downloaded files and state persist between container runs.

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,7 @@
+[voipms]
+username = YOUR_VOIPMS_USERNAME
+password = YOUR_VOIPMS_PASSWORD
+
+[paths]
+download_dir = ./recordings
+state_file = ./state.json

--- a/flux/README.md
+++ b/flux/README.md
@@ -1,0 +1,114 @@
+# Deploying the VoIP.ms Sync Script with Flux CD
+
+This directory contains the Kubernetes manifests required to deploy the call recording synchronization script using a GitOps approach with [Flux CD](https://fluxcd.io/).
+
+The setup is designed to be secure and production-ready, using an init container to handle configuration at runtime.
+
+## Overview of Resources
+
+This Kustomize base defines the following Kubernetes resources:
+
+- `PersistentVolumeClaim` (`pvc.yaml`): Creates a persistent volume to store the downloaded recordings and the `state.json` file, ensuring data is not lost between job runs.
+- `CronJob` (`cronjob.yaml`): Schedules the synchronization script to run every hour. It uses an init container to securely generate the configuration file from a Kubernetes secret.
+
+## Prerequisites
+
+1.  A running Kubernetes cluster.
+2.  [Flux CD](https://fluxcd.io/flux/installation/) installed and configured on your cluster.
+3.  The Docker image for this application pushed to a container registry that your Kubernetes cluster can access.
+
+## Configuration Steps
+
+### 1. Configure Image Automation (Optional)
+
+The `cronjob.yaml` manifest is already configured for Flux Image Update Automation. When a new version of the application image is pushed to the container registry, Flux can automatically update the `image` tag and commit the change back to your repository.
+
+To enable this, you will need to create `ImageRepository` and `ImagePolicy` resources in your cluster. See the [Flux Image Update Automation documentation](https://fluxcd.io/flux/guides/image-update/) for a detailed guide.
+
+The image line in `cronjob.yaml` that Flux will update is:
+```yaml
+# flux/cronjob.yaml
+...
+containers:
+  - name: voipms-sync-container
+    image: your-repo/voipms-sync:latest # {"$imagepolicy": "voip-sync:voipms-sync"}
+...
+```
+You will need to create an `ImagePolicy` named `voipms-sync` in the `voip-sync` namespace for this to work.
+
+### 2. Create the Credentials Secret
+
+This `CronJob` requires a Kubernetes `Secret` named `voipms-credentials` to exist in the `voip-sync` namespace. This secret must contain your VoIP.ms API username and password.
+
+You can create this secret by applying a manifest like the one below.
+
+**Important**: The `username` and `password` values must be **base64-encoded**.
+
+```yaml
+# voipms-credentials-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: voipms-credentials
+  namespace: voip-sync
+type: Opaque
+data:
+  # echo -n 'YOUR_USERNAME' | base64
+  username: WVdSUl9VU0VSTkFNRQ==
+  # echo -n 'YOUR_PASSWORD' | base64
+  password: WVdSUl9QQVNTV09SRA==
+```
+
+Apply this file to your cluster: `kubectl apply -f voipms-credentials-secret.yaml`.
+
+For a more secure, GitOps-friendly approach, it is highly recommended to manage this secret using a tool like [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) or [SOPS](https://github.com/mozilla/sops).
+
+## Deployment with Flux (from OCI)
+
+The CI pipeline for this repository publishes the Kustomize configuration in this directory as an OCI artifact. You should configure your Flux deployment to pull from this OCI artifact instead of directly from the Git repository.
+
+This approach decouples the deployment from the source code, leading to more reliable and secure deployments.
+
+First, you need to create an `OCIRepository` source in your cluster to tell Flux where to find the manifests.
+
+```yaml
+# oci-source.yaml
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: voipms-sync-manifests
+  namespace: flux-system
+spec:
+  interval: 10m
+  url: oci://ghcr.io/your-org/your-repo/manifests # <-- CHANGE THIS
+  ref:
+    semver: ">=0.1.0"
+```
+
+Next, create a `Kustomization` that points to this `OCIRepository` source.
+
+```yaml
+# kustomization.yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: voipms-sync
+  namespace: flux-system
+spec:
+  interval: 10m
+  prune: true
+  sourceRef:
+    kind: OCIRepository
+    name: voipms-sync-manifests # Must match the name of the OCIRepository above
+  targetNamespace: voip-sync
+```
+
+## How the `CronJob` Works
+
+The `CronJob` uses an **init container** to separate configuration from the application image.
+
+1.  The `voipms-credentials` secret is mounted as environment variables into the init container.
+2.  The init container runs a small shell script that writes a `config.ini` file to a shared `emptyDir` volume.
+3.  The main application container starts and mounts this generated `config.ini` file, ready to use.
+
+This pattern keeps the main Docker image generic and your secrets securely managed within the cluster.

--- a/flux/cronjob.yaml
+++ b/flux/cronjob.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: voipms-sync-cronjob
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          volumes:
+            - name: recordings-storage
+              persistentVolumeClaim:
+                claimName: voip-recordings-pvc
+            - name: config-volume
+              emptyDir: {}
+          initContainers:
+            - name: config-initializer
+              image: busybox:1.35
+              command: ['sh', '-c']
+              args:
+              - |
+                echo "[voipms]" > /config/config.ini
+                echo "username = $(VOIPMS_USERNAME)" >> /config/config.ini
+                echo "password = $(VOIPMS_PASSWORD)" >> /config/config.ini
+                echo "[paths]" >> /config/config.ini
+                echo "download_dir = /data/recordings" >> /config/config.ini
+                echo "state_file = /data/state.json" >> /config/config.ini
+              env:
+                - name: VOIPMS_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: voipms-credentials
+                      key: username
+                - name: VOIPMS_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: voipms-credentials
+                      key: password
+              volumeMounts:
+                - name: config-volume
+                  mountPath: /config
+          containers:
+            - name: voipms-sync-container
+              image: your-repo/voipms-sync:latest # {"$imagepolicy": "voip-sync:voipms-sync"}
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "128Mi"
+                limits:
+                  cpu: "200m"
+                  memory: "256Mi"
+              volumeMounts:
+                - name: recordings-storage
+                  mountPath: /data # The script will save recordings and state here
+                - name: config-volume
+                  mountPath: /app/config.ini # Mount the generated config file directly
+                  subPath: config.ini

--- a/flux/kustomization.yaml
+++ b/flux/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: voip-sync
+
+resources:
+  - pvc.yaml
+  - cronjob.yaml

--- a/flux/pvc.yaml
+++ b/flux/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: voip-recordings-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/sync_recordings.py
+++ b/sync_recordings.py
@@ -1,0 +1,189 @@
+import configparser
+import json
+import logging
+import os
+import time
+import requests
+
+# --- Constants ---
+# Base URL for the API. Assumed from the prompt.
+API_BASE_URL = "https://voip.ms/api/v1"
+# Maximum number of retries for network requests.
+MAX_RETRIES = 3
+
+def setup_logging():
+    """Configure logging to print to standard output."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+def fetch_recordings_list(username, password):
+    """
+    Fetches the list of available call recordings from the API.
+
+    Implements a retry mechanism with exponential backoff for resilience.
+
+    Args:
+        username (str): The VoIP.ms API username.
+        password (str): The VoIP.ms API password.
+
+    Returns:
+        list: A list of recording objects from the API, or None if an
+              unrecoverable error occurs.
+    """
+    url = f"{API_BASE_URL}/recordings"
+    params = {'username': username, 'password': password}
+
+    for attempt in range(MAX_RETRIES):
+        try:
+            response = requests.get(url, params=params, timeout=10)
+            response.raise_for_status()  # Raise an exception for bad status codes (4xx or 5xx)
+
+            # Assuming the actual list is nested under a 'recordings' key.
+            # If the structure is different, this line needs adjustment.
+            data = response.json()
+            if "recordings" in data and isinstance(data["recordings"], list):
+                logging.info("Successfully fetched the list of recordings from the API.")
+                return data["recordings"]
+            else:
+                logging.error(f"API response format is unexpected. Response: {data}")
+                return None
+
+        except requests.exceptions.RequestException as e:
+            logging.error(f"Attempt {attempt + 1}/{MAX_RETRIES}: Failed to connect to API: {e}")
+            if attempt < MAX_RETRIES - 1:
+                wait_time = 2 ** attempt  # Exponential backoff: 1, 2, 4 seconds
+                logging.info(f"Retrying in {wait_time} seconds...")
+                time.sleep(wait_time)
+            else:
+                logging.error("All retry attempts failed. Could not fetch recordings list.")
+                return None
+        except json.JSONDecodeError:
+            logging.error("Failed to decode JSON from API response.")
+            return None
+
+def download_single_recording(recording_id, username, password, download_path):
+    """
+    Downloads a single recording file from the API using a streaming approach.
+
+    Args:
+        recording_id (str): The unique identifier for the recording.
+        username (str): The VoIP.ms API username.
+        password (str): The VoIP.ms API password.
+        download_path (str): The full local path to save the file.
+
+    Returns:
+        bool: True if the download was successful, False otherwise.
+    """
+    url = f"{API_BASE_URL}/recordings/{recording_id}/file"
+    params = {'username': username, 'password': password}
+
+    try:
+        logging.info(f"Starting download for recording ID: {recording_id}")
+        with requests.get(url, params=params, stream=True, timeout=30) as r:
+            r.raise_for_status()
+            with open(download_path, 'wb') as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
+        logging.info(f"Successfully downloaded and saved to {download_path}")
+        return True
+    except requests.exceptions.RequestException as e:
+        logging.error(f"Failed to download recording {recording_id}. Error: {e}")
+        return False
+
+def synchronize_recordings(config):
+    """
+    Orchestrates the synchronization process.
+
+    - Loads local state.
+    - Fetches remote recordings list.
+    - Identifies and downloads new recordings.
+    - Updates local state.
+    """
+    # --- 1. Load configuration ---
+    try:
+        username = config['voipms']['username']
+        password = config['voipms']['password']
+        download_dir = config['paths']['download_dir']
+        state_file = config['paths']['state_file']
+    except KeyError as e:
+        logging.error(f"Configuration error: Missing key {e} in config.ini")
+        return
+
+    # --- 2. Create download directory if it doesn't exist ---
+    os.makedirs(download_dir, exist_ok=True)
+
+    # --- 3. Load local state ---
+    downloaded_ids = set()
+    if os.path.exists(state_file):
+        try:
+            with open(state_file, 'r') as f:
+                # Load IDs into a set for efficient lookups
+                downloaded_ids = set(json.load(f))
+            logging.info(f"Loaded {len(downloaded_ids)} previously downloaded recording IDs from state.")
+        except (json.JSONDecodeError, IOError) as e:
+            logging.error(f"Could not read or parse state file at {state_file}. Error: {e}")
+            # Depending on desired behavior, you might want to exit here.
+            # For resilience, we'll proceed assuming no prior state.
+            downloaded_ids = set()
+    else:
+        logging.info("State file not found. Starting with a clean state.")
+
+    # --- 4. Fetch list of available recordings ---
+    remote_recordings = fetch_recordings_list(username, password)
+    if remote_recordings is None:
+        logging.error("Halting synchronization due to failure in fetching recording list.")
+        return
+
+    # --- 5. Identify new recordings ---
+    remote_ids = {rec['id'] for rec in remote_recordings if 'id' in rec}
+    new_recording_ids = list(remote_ids - downloaded_ids)
+
+    if not new_recording_ids:
+        logging.info("No new recordings to download. Synchronization is complete.")
+        return
+
+    logging.info(f"Found {len(new_recording_ids)} new recordings to download.")
+
+    # --- 6. Download new recordings ---
+    successfully_downloaded_ids = []
+    for rec_id in new_recording_ids:
+        # Assuming a file extension. This could be made configurable.
+        file_path = os.path.join(download_dir, f"{rec_id}.mp3")
+        success = download_single_recording(rec_id, username, password, file_path)
+        if success:
+            successfully_downloaded_ids.append(rec_id)
+
+    # --- 7. Update state file ---
+    if successfully_downloaded_ids:
+        updated_ids = downloaded_ids.union(set(successfully_downloaded_ids))
+        try:
+            with open(state_file, 'w') as f:
+                # Convert set to list for JSON serialization
+                json.dump(list(updated_ids), f, indent=4)
+            logging.info(f"Successfully updated state file with {len(successfully_downloaded_ids)} new recordings.")
+        except IOError as e:
+            logging.error(f"Could not write to state file at {state_file}. Error: {e}")
+
+def main():
+    """Main entry point for the script."""
+    setup_logging()
+    logging.info("Starting call recording synchronization script.")
+
+    config = configparser.ConfigParser()
+    try:
+        if not config.read('config.ini'):
+            logging.error("Error: config.ini not found or is empty.")
+            return
+    except configparser.Error as e:
+        logging.error(f"Error parsing config.ini: {e}")
+        return
+
+    synchronize_recordings(config)
+
+    logging.info("Synchronization script finished.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit fixes two issues in the `containerize.yaml` workflow based on user feedback.

1.  A syntax error in the workflow expression for converting a string to lowercase has been corrected from `| lower` to the valid `lower()` function.
2.  The destination for the Kustomization OCI artifact has been updated to publish to a sub-repository of the main application image repository (e.g., `ghcr.io/owner/repo/manifests`). This logically groups the application and its manifests together.

The `flux/README.md` has also been updated to reflect the new OCI artifact URL.